### PR TITLE
Bugfix: declaration of compose must be compatible

### DIFF
--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -1,14 +1,15 @@
 VERMAS
 ------
 Verified gross mass transmission. Supports one or more containers per message.
-```php
-$p = (new EDI\Generator\Interchange('ME', 'YOU'));
 
-$v = (new EDI\Generator\Vermas())
+```php
+$oInterchange = (new \EDI\Generator\Interchange('ME', 'YOU'));
+
+$oVermas = (new \EDI\Generator\Vermas())
     ->setMessageSender('IC', '', 'JOHN DOE')
     ->setMessageSenderInformation('EM', 'TEST@EXAMPLE.COM');
 
-$c = (new EDI\Generator\Vermas\Container())
+$oContainer = (new \EDI\Generator\Vermas\Container())
     ->setContainer('CBHU1234567', '22G1')
     ->setBooking('4001234567', '1')
     ->setSeal('45545', 'CA')
@@ -18,147 +19,316 @@ $c = (new EDI\Generator\Vermas\Container())
     ->setShipper('MY COMPANY')
     ->setSpcContact('RP', 'JOHN DOE', 'EM', 'JOHN@EXAMPLE.COM');
 
-$v = $v->addContainer($c);
+$oVermas = $oVermas->addContainer($oContainer);
 
-$v = $v->compose(5);
+$oVermas = $oVermas->compose(5, 749);
 
-$p = $p->addMessage($v)->getComposed();
+$aComposed = $oInterchange->addMessage($oVermas)->getComposed();
 
-echo (new EDI\Encoder($p, false))->get();
+echo (new \EDI\Encoder($aComposed, false))->get();
+```
+
+```
+UNB+UNOA:2+ME+YOU+190130:2039+I5C51FD6BE2EEA'
+UNH+M5C51FD6BE3109+VERMAS:D:16A:UN:SMDG10'
+BGM+749+M5C51FD6BE3109+5'
+DTM+137:201901302039:203'
+NAD+TB'
+CTA+IC+:JOHN DOE'
+COM+TEST@EXAMPLE.COM:EM'
+EQD+CN+CBHU1234567+22G1:6346:306'
+RFF+BN:4001234567'
+RFF+SQ:1'
+SEL+45545:CA'
+MEA+AAE+VGM+KGM:1212'
+DTM+798:201901302039:203'
+DOC+SM1:VGM:306+DEFAULT'
+NAD+SPC+++MY COMPANY'
+CTA+RP+:JOHN DOE'
+COM+JOHN@EXAMPLE.COM:EM'
+UNT+17+M5C51FD6BE3109'
+UNZ+1+I5C51FD6BE2EEA'
 ```
 COPINO
 ------
 Transportation order. Only one container per message.
+
 ```php
-$p = (new EDI\Generator\Interchange('ME', 'YOU'));
-$copino = (new \EDI\Generator\Copino())
-->setSenderAndReceiver('ME', 'YOU')
-->setDTM('201204260000')
-->setTransporter('12000051161000025', 8, '', 'TRUCKER CORP.', 'XA212345', 'JOHN DOE')
-->setVessel('CARRIER', 'XNOE', 'NOE VESSEL')
-->setContainer('CBHU1234567', '22G1', '4001234567', '1')
-->setMeasures('G', 11000)
-->setPort('ITGOA', 'VTE')
-->setDestination('HKHKG');
+$oInterchange = (new \EDI\Generator\Interchange('ME', 'YOU'));
 
-$copino = $copino->compose(5);
+$oCopino = (new \EDI\Generator\Copino())
+    ->setSenderAndReceiver('ME', 'YOU')
+    ->setDTM('201204260000')
+    ->setTransporter('12000051161000025', 8, '', 'TRUCKER CORP.', 'XA212345', 'JOHN DOE')
+    ->setVessel('CARRIER', 'XNOE', 'NOE VESSEL')
+    ->setContainer('CBHU1234567', '22G1', '4001234567', '1')
+    ->setMeasures('G', 11000)
+    ->setPort('ITGOA', 'VTE')
+    ->setDestination('HKHKG');
 
-$p = $p->addMessage($copino)->getComposed();
+$oCopino = $oCopino->compose(9, 661);
 
-echo (new EDI\Encoder($p, false))->get();
+$aComposed = $oInterchange->addMessage($oCopino)->getComposed();
+
+echo (new \EDI\Encoder($aComposed, false))->get();
 ```
+
+```
+UNB+UNOA:2+ME+YOU+190130:2046+I5C51FF1C8CD34'
+UNH+M5C51FF1C8CF9A+COPINO:D:95B:UN:ITG13'
+BGM+661+M5C51FF1C8CF9A+9'
+RFF+XXX:1'
+TDT+1+12000051161000025+8++TRUCKER CORP.+++XA212345:146::JOHN DOE'
+LOC+88+ITGOA:139:6+VTE:72:306'
+DTM+132:201204260000:203'
+NAD+MS+ME'
+NAD+MR+YOU'
+GID+1'
+SGP+CBHU1234567'
+EQD+CN+CBHU1234567+22G1:102:5++2+5'
+RFF+BN:4001234567'
+RFF+SQ:1'
+MEA+AAE+G+KGM:11000'
+TDT+20++1+13+CARRIER+++XNOE:103::NOE VESSEL'
+LOC+7+HKHKG:139:6'
+CNT+16:1'
+UNT+18+M5C51FF1C8CF9A'
+UNZ+1+I5C51FF1C8CD34'
+```
+
 COPARN
 ------
 Container announcement. One container per message. This example shows a full acceptance order sent to the terminal (documentType = 126).
+
 ```php
-$inc = (new EDI\Generator\Interchange('ME', 'YOU'));
-$v = (new EDI\Generator\Coparn());
+$oInterchange = (new \EDI\Generator\Interchange('ME', 'YOU'));
 
-$v->setBooking('400123456', '0001')
-  ->setRFFOrder('TEMPORDER');
-$v->setVessel('0002W', 'COS', 'NOE VESSEL', 'XNOE');
-$v->setETA('201701210000')
+$oCoparn = (new \EDI\Generator\Coparn())
+    ->setBooking('400123456', '0001')
+    ->setRFFOrder('TEMPORDER')
+    ->setVessel('0002W', 'COS', 'NOE VESSEL', 'XNOE')
+    ->setETA('201701210000')
     ->setETD('201701210000')
-    ->setPOL('ITGOA')->setPOD('HKHKG')->setFND('HKHKG')->setCarrier('COS');
+    ->setPOL('ITGOA')
+    ->setPOD('HKHKG')
+    ->setFND('HKHKG')
+    ->setCarrier('COS')
+    ->setContainer('CBHU1234567', '22G1')
+    ->setVGM('11495.14', '201701210000')
+    ->setTemperature('14.3')
+    ->setDangerous(3, 1366)
+    ->setOverDimensions(0, 0, 0, 0, 7.5)
+    ->setCargoCategory('GENERAL CARGO')
+;
 
-$v->setContainer('CBHU1234567', '22G1');
+$oCoparn = $oCoparn->compose(5, 126);
 
-$v->setVGM('11495.14', '201701210000');
-$v->setTemperature('14.3');
-$v->setDangerous(3, 1366);
-$v->setOverDimensions(0, 0, 0, 0, 7.5);
+$aComposed = $oInterchange->addMessage($oCoparn)->getComposed();
 
-$v->setCargoCategory('GENERAL CARGO');
-$v = $v->compose(9);
-$inc = $inc->addMessage($v)->getComposed();
+echo (new \EDI\Encoder($aComposed, false))->get();
+```
 
-$incText = (new EDI\Encoder($inc, false))->get();
+```
+UNB+UNOA:2+ME+YOU+190130:2054+I5C5201079DADD'
+UNH+M5C5201079DE48+COPARN:D:00B:UN:SMDG20'
+BGM+126+M5C5201079DE48+5+AB'
+DTM+137:201901302054:203'
+RFF+ATX:TEMPORDER'
+RFF+BN:400123456'
+TDT+20+0002W+++COS:172:20+++XNOE:146:11:NOE VESSEL'
+RFF+VM:XNOE'
+LOC+9+ITGOA:139:6'
+DTM+132:201701210000:203'
+DTM+133:201701210000:203'
+NAD+MS+COS:160:ZZZ'
+NAD+CF+COS:160:166'
+EQD+CN+CBHU1234567+22G1:102:5++2+5'
+RFF+SQ:0001'
+TMD+3'
+DTM+798:201701210000:203'
+LOC+7+HKHKG:139:6'
+LOC+9+ITGOA:139:6'
+LOC+11+HKHKG:139:6'
+MEA+AAE+VGM+KGM:11495.14'
+DIM+5+CMT:0'
+DIM+6+CMT:0'
+DIM+7+CMT::0'
+DIM+8+CMT::0'
+DIM+13+CMT:::7.5'
+TMP+2+14.3:CEL'
+FTX+AAA+++GENERAL CARGO'
+DGS+IMD+3+1366'
+TDT+1++3'
+CNT+16:1'
+UNT+31+M5C5201079DE48'
+UNZ+1+I5C5201079DADD'
+```
+
 ```
 CODECO
 ------
 Container move report. Multiple containers per message. Each message can be for gate in or for gate out.
+
 ```php
-$inc = (new EDI\Generator\Interchange('ME', 'YOU'));
-$v = (new EDI\Generator\Codeco());
+$oInterchange = (new \EDI\Generator\Interchange('ME', 'YOU'));
 
-$v->setSenderAndReceiver('ITPIALOMA', 'COSCOS');
-$v->setCarrier('COS');
+$oCodeco = (new \EDI\Generator\Codeco())
+    ->setSenderAndReceiver('ITPIALOMA', 'COSCOS')
+    ->setCarrier('COS')
+;
 
-$c = (new EDI\Generator\Codeco\Container());
-$c->setContainer('CBHU1234567', '22G1', 2, 5);
-$c->setBooking('4006531400');
-$c->setEffectiveDate('201701020800');
-$c->setSeal('1234567', 'CA');
-$c->setModeOfTransport(3, 31);
-$c->setWeight('G', 15400);
+$oContainer = (new \EDI\Generator\Codeco\Container())
+    ->setContainer('CBHU1234567', '22G1', 2, 5)
+    ->setBooking('4006531400')
+    ->setEffectiveDate('201701020800')
+    ->setSeal('1234567', 'CA')
+    ->setModeOfTransport(3, 31)
+    ->setWeight('G', 15400)
+;
 
-$v = $v->addContainer($c);
+$oCodeco = $oCodeco->addContainer($oContainer);
 
-$v = $v->compose(9);
-$inc = $inc->addMessage($v)->getComposed();
+$oCodeco = $oCodeco->compose(5, 34);
 
-$incText = (new EDI\Encoder($inc, false))->get();
+$aComposed = $oInterchange->addMessage($oCodeco)->getComposed();
+
+echo (new \EDI\Encoder($aComposed, false))->get();
 ```
+
+```
+UNB+UNOA:2+ME+YOU+190130:2101+I5C520285973E2'
+UNH+M5C52028597E23+CODECO:D:95B:UN'
+BGM+34+M5C52028597E23+5'
+NAD+MS+ITPIALOMA'
+NAD+MR+COSCOS'
+NAD+CF+COS:160:166'
+EQD+CN+CBHU1234567+22G1:6346:306++2+5'
+RFF+BN:4006531400'
+DTM+7:201701020800:203'
+MEA+AAE+G+KGM:15400'
+SEL+1234567:CA'
+TDT+1++3+31'
+CNT+16:1'
+UNT+13+M5C52028597E23'
+UNZ+1+I5C520285973E2'
+```
+
 COPRAR
 ------
 Container load or discharge order.  Multiple containers per message. The example is a loading order.
+
 ```php
-$p = (new EDI\Generator\Interchange('ME', 'YOU'));
+$oInterchange = (new \EDI\Generator\Interchange('ME', 'YOU'));
 
-$v = (new EDI\Generator\Coprar());
-$v->setVessel('0002W', 'COS', 'NOE VESSEL', 'XNOE');
-$v->setPort(9, 'ITGOA');
-$v->setETA('201701210000')
-    ->setETD('201701210000');
-$v->setCarrier('COS');
+$oCoprar = (new \EDI\Generator\Coprar())
+    ->setVessel('0002W', 'COS', 'NOE VESSEL', 'XNOE')
+    ->setPort(9, 'ITGOA')
+    ->setETA('201701210000')
+    ->setETD('201701210000')
+    ->setCarrier('COS')
+;
 
-$c= (new EDI\Generator\Coprar\Container());
-$c->setContainer('CBHU1234567', '22G1', 2, 5);
-$c->setBooking('4006531400');
-$c->setPOD('HKHKG')->setFND('HKHKG');
+$oContainer = (new \EDI\Generator\Coprar\Container())
+    ->setContainer('CBHU1234567', '22G1', 2, 5)
+    ->setBooking('4006531400')
+    ->setPOD('HKHKG')->setFND('HKHKG')
+    ->setVGM('11495.14', '201701210000')
+    ->setTemperature('14.3')
+    ->setDangerous(3, 1366)
+    ->setOverDimensions(0, 0, 0, 0, 7.5)
+    ->setCargoCategory('GENERAL CARGO')
+    ->setContainerOperator('COS')
+;
 
-$c->setVGM('11495.14', '201701210000');
-$c->setTemperature('14.3');
-$c->setDangerous(3, 1366);
-$c->setOverDimensions(0, 0, 0, 0, 7.5);
+$oCoprar = $oCoprar->addContainer($oContainer);
 
-$c->setCargoCategory('GENERAL CARGO');
-$c->setContainerOperator('COS');
+$oCoprar = $oCoprar->compose(5, 45);
 
-$v = $v->addContainer($c);
+$aComposed = $oInterchange->addMessage($oCoprar)->getComposed();
 
-$v = $v->compose(5, 45);
-
-$inc = $p->addMessage($v)->getComposed();
-$incText = (new EDI\Encoder($inc, false))->get();
+echo (new \EDI\Encoder($aComposed, false))->get();
 ```
+
+```
+UNB+UNOA:2+ME+YOU+190130:2107+I5C5204015D145'
+UNH+M5C5204015D3A1+COPRAR:D:95B:UN:SMDG16'
+BGM+45+M5C5204015D3A1+5'
+RFF+XXX:1'
+TDT+20+0002W+1++COS:172:20+++XNOE:103::NOE VESSEL'
+LOC+9+ITGOA:139:6'
+DTM+132:201701210000:203'
+DTM+133:201701210000:203'
+NAD+CA+COS:160:20'
+EQD+CN+CBHU1234567+22G1:102:5++2+5'
+RFF+BN:4006531400'
+DTM+798:201701210000:203'
+LOC+11+HKHKG:139:6'
+LOC+7+HKHKG:139:6'
+MEA+AAE+VGM+KGM:11495.14'
+DIM+5+CMT:0'
+DIM+6+CMT:0'
+DIM+7+CMT::0'
+DIM+8+CMT::0'
+DIM+13+CMT:::7.5'
+TMP+2+14.3:CEL'
+FTX+AAA+++GENERAL CARGO'
+DGS+IMD+3+1366'
+NAD+CF+COS:160:20'
+CNT+16:1'
+UNT+25+M5C5204015D3A1'
+UNZ+1+I5C5204015D145'
+```
+
 WESTIM
 ------
 Container MNR message (ISO EDI, not UN/EDIFACT). One container per message.
+
 ```php
-$p = (new EDI\Generator\Interchange('IT888XXXX', 'CARRIER'));
+$oInterchange = (new \EDI\Generator\Interchange('IT888XXXX', 'CARRIER'));
 
-$v = (new EDI\Generator\Westim('ESTNUMBER'));
+$oWestim = (new \EDI\Generator\Westim('ESTNUMBER'))
+    ->setTransactionDate('170702')->setCurrency('EUR')->setLabourRate('100.00')
+    ->setPartners('IT888XXXX', 'CARRIER')
+    ->setContainer('CBHU', '1234567', '4510')
+    ->setFullEmpty('E')
+    ->setCostTotals('O', '4.5', '82.63', '0', '0', '87.13')
+    ->setTotalMessageAmounts('87.13')
+;
 
-$v->setTransactionDate('170702')->setCurrency('EUR')->setLabourRate('100.00');
-$v->setPartners('IT888XXXX', 'CARRIER');
-$v->setContainer('CBHU', '1234567', '4510');
-$v->setFullEmpty('E');
+$oDamage = (new \EDI\Generator\Westim\Damage())
+    ->setDamage('01', 'IXXX', 'TFA', 'DB', 'SK')
+    ->setWork('SC', '', '0', '1', '', '1')
+    ->setCost('0', '82.63', 'O', '18.00')
+;
 
-$d = (new EDI\Generator\Westim\Damage());
-$d->setDamage('01', 'IXXX', 'TFA', 'DB', 'SK');
-$d->setWork('SC', '', '0', '1', '', '1');
-$d->setCost('0', '82.63', 'O', '18.00');
-$v->addDamage($d);
+$oWestim->addDamage($oDamage);
 
-$v->setCostTotals('O', '4.5', '82.63', '0', '0', '87.13');
+$oWestim = $oWestim->compose();
 
-$v->setTotalMessageAmounts('87.13');
+$aComposed = $oInterchange->addMessage($oWestim)->getComposed();
 
-$v = $v->compose();
+echo (new \EDI\Encoder($aComposed, false))->get();
+```
 
-$inc = $p->addMessage($v)->getComposed();
-$incText = (new EDI\Encoder($inc, false))->get();
+```
+UNB+UNOA:2+IT888XXXX+CARRIER+190130:2121+I5C520753A0FDB'
+UNH+ESTNUMBER+WESTIM:0'
+DTM+ATR+170702'
+RFF+EST+ESTNUMBER+170702'
+ACA+EUR+STD:0'
+LBR+100.00'
+NAD+LED+CARRIER'
+NAD+DED+IT888XXXX'
+EQF+CON+CBHU:1234567+4510+MGW:0:KGM'
+CUI+++E'
+ECI+D'
+DAM+01+IXXX+TFA+DB+SK'
+WOR+SC+:0:1:+1'
+COS+0+0+82.63+O+18.00+N'
+CTO+O+4.5+82.63+0+0+87.13'
+TMA+87.13'
+UNT+16+ESTNUMBER'
+UNZ+1+I5C520753A0FDB'
 ```
 
 COHAOR
@@ -301,14 +471,14 @@ $oCohaor->compose(9, 293, $sDocumentIdentifier);
 
 $aComposed = $oInterchange->addMessage($oCohaor)->getComposed();
 
-$sComposed = (new \EDI\Encoder($aComposed, false))->get();
+echo (new \EDI\Encoder($aComposed, false))->get();
 ```
 
 ```
-UNB+UNOA:2+ME+YOU+181203:1021+I5C04F58A8CA7C'
+UNB+UNOA:2+ME+YOU+190130:2015+I5C51F7D31CFF8'
 UNH+ROW00000000001+COHAOR:D:17B:UN:ITG12'
-BGM+293+5c04f58a8e778+9'
-NAD++My Party+My Company:My Address:1234 AB+++My City++123456+NL'
+BGM+293+5c51f7d31e599+9'
+NAD++My Party+My Company:My Address:1234 AB+My City+123456+NL'
 EQD+AM+123456+1234::5:'
 DTM+7:201812031015:203'
 LOC+9+NLRTM'
@@ -318,5 +488,5 @@ TMP+SET+13.00:CEL'
 RNG+5+CEL:10.00:15.00'
 CNT+16:1'
 UNT+12+ROW00000000001'
-UNZ+1+I5C04F58A8CA7C'
+UNZ+1+I5C51F7D31CFF8'
 ```

--- a/src/Generator/Calinf.php
+++ b/src/Generator/Calinf.php
@@ -11,13 +11,30 @@ class Calinf extends Message
     private $etd;
     private $callsign;
 
-    public function __construct($messageID = null, $identifier = 'CALINF', $version = 'D', $release = '00B', $controllingAgency = 'UN', $association = 'SMDG20')
-    {
-        parent::__construct($identifier, $version, $release, $controllingAgency, $messageID, $association);
+    private $containers = [];
+
+    /**
+     * Construct.
+     *
+     * @param mixed $sMessageReferenceNumber (0062)
+     * @param string $sMessageType (0065)
+     * @param string $sMessageVersionNumber (0052)
+     * @param string $sMessageReleaseNumber (0054)
+     * @param string $sMessageControllingAgencyCoded (0051)
+     * @param string $sAssociationAssignedCode (0057)
+     */
+    public function __construct(
+        $sMessageReferenceNumber = null,
+        $sMessageType = 'CALINF',
+        $sMessageVersionNumber = 'D',
+        $sMessageReleaseNumber = '00B',
+        $sMessageControllingAgencyCoded = 'UN',
+        $sAssociationAssignedCode = 'SMDG20'
+    ) {
+        parent::__construct($sMessageType, $sMessageVersionNumber, $sMessageReleaseNumber,
+            $sMessageControllingAgencyCoded, $sMessageReferenceNumber, $sAssociationAssignedCode);
 
         $this->dtmSend = self::dtmSegment(137, date('YmdHi'));
-
-        $this->containers = [];
     }
 
     /*
@@ -81,10 +98,19 @@ class Calinf extends Message
         return $this;
     }
 
-    public function compose($msgStatus = 5, $documentCode = 96)
+    /**
+     * Compose.
+     *
+     * @param mixed $sMessageFunctionCode (1225)
+     * @param mixed $sDocumentNameCode (1001)
+     * @param mixed $sDocumentIdentifier (1004)
+     *
+     * @return parent::compose()
+     */
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
         $this->messageContent = [
-            ['BGM', $documentCode, $this->messageID, $msgStatus]
+            ['BGM', $sDocumentNameCode, $this->messageID, $sMessageFunctionCode]
         ];
 
         $this->messageContent[] = $this->dtmSend;
@@ -95,7 +121,6 @@ class Calinf extends Message
         $this->messageContent[] = $this->etd;
         $this->messageContent[] = $this->callsign;
 
-        parent::compose();
-        return $this;
+        return parent::compose($sMessageFunctionCode, $sDocumentNameCode, $sDocumentIdentifier);
     }
 }

--- a/src/Generator/Codeco.php
+++ b/src/Generator/Codeco.php
@@ -7,13 +7,28 @@ class Codeco extends Message
     private $receiver;
     private $messageCF;
 
-    private $containers;
+    private $containers = [];
 
-    public function __construct($messageID = null, $identifier = 'CODECO', $version = 'D', $release = '95B', $controllingAgency = 'UN', $association = null)
-    {
-        parent::__construct($identifier, $version, $release, $controllingAgency, $messageID, $association);
-
-        $this->containers = [];
+    /**
+     * Construct.
+     *
+     * @param mixed $sMessageReferenceNumber (0062)
+     * @param string $sMessageType (0065)
+     * @param string $sMessageVersionNumber (0052)
+     * @param string $sMessageReleaseNumber (0054)
+     * @param string $sMessageControllingAgencyCoded (0051)
+     * @param string $sAssociationAssignedCode (0057)
+     */
+    public function __construct(
+        $sMessageReferenceNumber = null,
+        $sMessageType = 'CODECO',
+        $sMessageVersionNumber = 'D',
+        $sMessageReleaseNumber = '95B',
+        $sMessageControllingAgencyCoded = 'UN',
+        $sAssociationAssignedCode = null
+    ) {
+        parent::__construct($sMessageType, $sMessageVersionNumber, $sMessageReleaseNumber,
+            $sMessageControllingAgencyCoded, $sMessageReferenceNumber, $sAssociationAssignedCode);
     }
 
     /*
@@ -41,13 +56,19 @@ class Codeco extends Message
         return $this;
     }
 
-    /*
-     * $documentCode = 34 (gate in), 36 (gate out)
+    /**
+     * Compose.
+     *
+     * @param mixed $sMessageFunctionCode (1225)
+     * @param mixed $sDocumentNameCode (1001)
+     * @param mixed $sDocumentIdentifier (1004)
+     *
+     * @return parent::compose()
      */
-    public function compose($msgStatus = 5, $documentCode = 34)
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
         $this->messageContent = [
-            ['BGM', $documentCode, $this->messageID, $msgStatus]
+            ['BGM', $sDocumentNameCode, $this->messageID, $sMessageFunctionCode]
         ];
 
         if ($this->sender !== null) {
@@ -68,7 +89,7 @@ class Codeco extends Message
         }
 
         $this->messageContent[] = ['CNT', [16, count($this->containers)]];
-        parent::compose();
-        return $this;
+
+        return parent::compose($sMessageFunctionCode, $sDocumentNameCode, $sDocumentIdentifier);
     }
 }

--- a/src/Generator/Cohaor.php
+++ b/src/Generator/Cohaor.php
@@ -51,7 +51,7 @@ class Cohaor extends Message
      *
      * @return parent::compose()
      */
-    public function compose(?string $sMessageFunctionCode, ?string $sDocumentNameCode, ?string $sDocumentIdentifier): parent
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
         // BGM - Beginning of message
 

--- a/src/Generator/Coparn.php
+++ b/src/Generator/Coparn.php
@@ -28,13 +28,30 @@ class Coparn extends Message
     private $cargo;
     private $dimensions;
 
-    public function __construct($messageID = null, $identifier = 'COPARN', $version = 'D', $release = '00B', $controllingAgency = 'UN', $association = 'SMDG20')
-    {
-        parent::__construct($identifier, $version, $release, $controllingAgency, $messageID, $association);
+    private $containers = [];
+
+    /**
+     * Construct.
+     *
+     * @param mixed $sMessageReferenceNumber (0062)
+     * @param string $sMessageType (0065)
+     * @param string $sMessageVersionNumber (0052)
+     * @param string $sMessageReleaseNumber (0054)
+     * @param string $sMessageControllingAgencyCoded (0051)
+     * @param string $sAssociationAssignedCode (0057)
+     */
+    public function __construct(
+        $sMessageReferenceNumber = null,
+        $sMessageType = 'COPARN',
+        $sMessageVersionNumber = 'D',
+        $sMessageReleaseNumber = '00B',
+        $sMessageControllingAgencyCoded = 'UN',
+        $sAssociationAssignedCode = 'SMDG20'
+    ) {
+        parent::__construct($sMessageType, $sMessageVersionNumber, $sMessageReleaseNumber,
+            $sMessageControllingAgencyCoded, $sMessageReferenceNumber, $sAssociationAssignedCode);
 
         $this->dtmSend = self::dtmSegment(137, date('YmdHi'));
-
-        $this->containers = [];
     }
 
     /*
@@ -258,16 +275,27 @@ class Coparn extends Message
         return $this;
     }
 
-    public function compose($msgStatus = 5, $documentCode = 126)
+    /**
+     * Compose.
+     *
+     * @param mixed $sMessageFunctionCode (1225)
+     * @param mixed $sDocumentNameCode (1001)
+     * @param mixed $sDocumentIdentifier (1004)
+     *
+     * @return parent::compose()
+     */
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
         $this->messageContent = [
-            ['BGM', $documentCode, $this->messageID, $msgStatus, 'AB']
+            ['BGM', $sDocumentNameCode, $this->messageID, $sMessageFunctionCode, 'AB']
         ];
 
         $this->messageContent[] = $this->dtmSend;
+
         if ($this->rffAcceptOrder !== null) {
             $this->messageContent[] = $this->rffAcceptOrder;
         }
+
         $this->messageContent[] = $this->booking;
         $this->messageContent[] = $this->vessel;
         $this->messageContent[] = $this->callsign;
@@ -278,13 +306,17 @@ class Coparn extends Message
         $this->messageContent[] = $this->messageCF;
         $this->messageContent[] = $this->cntr;
         $this->messageContent[] = $this->bookingSequence;
+
         if ($this->cntr  === '') {
             $this->messageContent[] = $this->cntrAmount;
         }
+
         $this->messageContent[] = ['TMD', '3'];
+
         if ($this->weightTime !== null) {
             $this->messageContent[] = $this->weightTime;
         }
+
         $this->messageContent[] = $this->fnd;
         $this->messageContent[] = $this->pol;
         $this->messageContent[] = $this->pod;
@@ -293,6 +325,7 @@ class Coparn extends Message
         if ($this->ventilation !== null) {
             $this->messageContent[] = $this->ventilation;
         }
+
         if ($this->humidity !== null) {
             $this->messageContent[] = $this->humidity;
         }
@@ -302,20 +335,24 @@ class Coparn extends Message
                 $this->messageContent[] = $segment;
             }
         }
+
         if ($this->temperature !== null) {
             $this->messageContent[] = $this->temperature;
         }
+
         if ($this->cargo !== null) {
             $this->messageContent[] = $this->cargo;
         }
+
         if ($this->dangerous !== null) {
             foreach ($this->dangerous as $segment) {
                 $this->messageContent[] = $segment;
             }
         }
+
         $this->messageContent[] = ['TDT', 1, '', 3];
         $this->messageContent[] = ['CNT', [16, 1]];
-        parent::compose();
-        return $this;
+
+        return parent::compose($sMessageFunctionCode, $sDocumentNameCode, $sDocumentIdentifier);
     }
 }

--- a/src/Generator/Copino.php
+++ b/src/Generator/Copino.php
@@ -10,15 +10,29 @@ class Copino extends Message
     private $port;
     private $destination;
     private $dtm;
-    private $cntr;
-    private $measures;
+    private $cntr = [];
+    private $measures = [];
 
-    public function __construct($messageID = null, $identifier = 'COPINO', $version = 'D', $release = '95B', $controllingAgency = 'UN', $association = 'ITG13')
-    {
-        parent::__construct($identifier, $version, $release, $controllingAgency, $messageID, $association);
-
-        $this->cntr = [];
-        $this->measures = [];
+    /**
+     * Construct.
+     *
+     * @param mixed $sMessageReferenceNumber (0062)
+     * @param string $sMessageType (0065)
+     * @param string $sMessageVersionNumber (0052)
+     * @param string $sMessageReleaseNumber (0054)
+     * @param string $sMessageControllingAgencyCoded (0051)
+     * @param string $sAssociationAssignedCode (0057)
+     */
+    public function __construct(
+        $sMessageReferenceNumber = null,
+        $sMessageType = 'COPINO',
+        $sMessageVersionNumber = 'D',
+        $sMessageReleaseNumber = '95B',
+        $sMessageControllingAgencyCoded = 'UN',
+        $sAssociationAssignedCode = 'ITG13'
+    ) {
+        parent::__construct($sMessageType, $sMessageVersionNumber, $sMessageReleaseNumber,
+            $sMessageControllingAgencyCoded, $sMessageReferenceNumber, $sAssociationAssignedCode);
     }
 
     public function setSenderAndReceiver($sender, $receiver)
@@ -100,33 +114,41 @@ class Copino extends Message
         return $this;
     }
 
-    /*
-     * $documentCode = 660 (delivery) / 661 (pickup)
+    /**
+     * Compose.
+     *
+     * @param mixed $sMessageFunctionCode (1225)
+     * @param mixed $sDocumentNameCode (1001)
+     * @param mixed $sDocumentIdentifier (1004)
+     *
+     * @return parent::compose()
      */
-    public function compose($msgStatus = 9, $documentCode = 661)
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
         $this->messageContent = [
-            ['BGM', $documentCode, $this->messageID, $msgStatus],
+            ['BGM', $sDocumentNameCode, $this->messageID, $sMessageFunctionCode],
             self::rffSegment('XXX', 1)
         ];
 
         if (count($this->transporter) > 0) {
             $this->messageContent[] = $this->transporter;
         }
+
         $this->messageContent[] = $this->port;
         $this->messageContent[] = $this->dtm;
         $this->messageContent[] = $this->sender;
         $this->messageContent[] = $this->receiver;
         $this->messageContent[] = ['GID', 1];
+
         foreach ($this->cntr as $segment) {
             $this->messageContent[] = $segment;
         }
+
         $this->messageContent[] = $this->measures;
         $this->messageContent[] = $this->vessel;
         $this->messageContent[] = $this->destination;
         $this->messageContent[] = ['CNT', [16, 1]];
 
-        parent::compose();
-        return $this;
+        return parent::compose($sMessageFunctionCode, $sDocumentNameCode, $sDocumentIdentifier);
     }
 }

--- a/src/Generator/Coprar.php
+++ b/src/Generator/Coprar.php
@@ -9,13 +9,28 @@ class Coprar extends Message
     private $eta;
     private $etd;
 
-    private $containers;
+    private $containers = [];
 
-    public function __construct($messageID = null, $identifier = 'COPRAR', $version = 'D', $release = '95B', $controllingAgency = 'UN', $association = 'SMDG16')
-    {
-        parent::__construct($identifier, $version, $release, $controllingAgency, $messageID, $association);
-
-        $this->containers = [];
+    /**
+     * Construct.
+     *
+     * @param mixed $sMessageReferenceNumber (0062)
+     * @param string $sMessageType (0065)
+     * @param string $sMessageVersionNumber (0052)
+     * @param string $sMessageReleaseNumber (0054)
+     * @param string $sMessageControllingAgencyCoded (0051)
+     * @param string $sAssociationAssignedCode (0057)
+     */
+    public function __construct(
+        $sMessageReferenceNumber = null,
+        $sMessageType = 'COPRAR',
+        $sMessageVersionNumber = 'D',
+        $sMessageReleaseNumber = '95B',
+        $sMessageControllingAgencyCoded = 'UN',
+        $sAssociationAssignedCode = 'SMDG16'
+    ) {
+        parent::__construct($sMessageType, $sMessageVersionNumber, $sMessageReleaseNumber,
+            $sMessageControllingAgencyCoded, $sMessageReferenceNumber, $sAssociationAssignedCode);
     }
 
     /*
@@ -83,14 +98,19 @@ class Coprar extends Message
         return $this;
     }
 
-    /*
-     * $documentCode = 43 (discharge), 45 (loading)
-     * $msgStatus = 9 (original), 5 (replacement)
+    /**
+     * Compose.
+     *
+     * @param mixed $sMessageFunctionCode (1225)
+     * @param mixed $sDocumentNameCode (1001)
+     * @param mixed $sDocumentIdentifier (1004)
+     *
+     * @return parent::compose()
      */
-    public function compose($msgStatus = 9, $documentCode = 45)
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
         $this->messageContent = [
-            ['BGM', $documentCode, $this->messageID, $msgStatus],
+            ['BGM', $sDocumentNameCode, $this->messageID, $sMessageFunctionCode],
             self::rffSegment('XXX', 1)
         ];
 
@@ -102,16 +122,18 @@ class Coprar extends Message
 
         foreach ($this->containers as $cntr) {
             $content = $cntr;
+
             if (is_a($cntr, 'EDI\Generator\Coprar\Container')) {
                 $content = $cntr->compose();
             }
+
             foreach ($content as $segment) {
                 $this->messageContent[] = $segment;
             }
         }
 
         $this->messageContent[] = ['CNT', [16, count($this->containers)]];
-        parent::compose();
-        return $this;
+
+        return parent::compose($sMessageFunctionCode, $sDocumentNameCode, $sDocumentIdentifier);
     }
 }

--- a/src/Generator/Coreor.php
+++ b/src/Generator/Coreor.php
@@ -24,9 +24,26 @@ class Coreor extends Message
     private $emptyDepot;
     private $freightPayer;
 
-    public function __construct($messageID = null, $identifier = 'COREOR', $version = 'D', $release = '00B', $controllingAgency = 'UN', $association = 'SMDG20')
-    {
-        parent::__construct($identifier, $version, $release, $controllingAgency, $messageID, $association);
+    /**
+     * Construct.
+     *
+     * @param mixed $sMessageReferenceNumber (0062)
+     * @param string $sMessageType (0065)
+     * @param string $sMessageVersionNumber (0052)
+     * @param string $sMessageReleaseNumber (0054)
+     * @param string $sMessageControllingAgencyCoded (0051)
+     * @param string $sAssociationAssignedCode (0057)
+     */
+    public function __construct(
+        $sMessageReferenceNumber = null,
+        $sMessageType = 'COREOR',
+        $sMessageVersionNumber = 'D',
+        $sMessageReleaseNumber = '00B',
+        $sMessageControllingAgencyCoded = 'UN',
+        $sAssociationAssignedCode = 'SMDG20'
+    ) {
+        parent::__construct($sMessageType, $sMessageVersionNumber, $sMessageReleaseNumber,
+            $sMessageControllingAgencyCoded, $sMessageReferenceNumber, $sAssociationAssignedCode);
 
         $this->dtmSend = self::dtmSegment(137, date('YmdHi'));
     }
@@ -198,20 +215,29 @@ class Coreor extends Message
         return $this;
     }
 
-     /*
-     * $documentCode = 129 (Transport cargo release order)
+    /**
+     * Compose.
+     *
+     * @param mixed $sMessageFunctionCode (1225)
+     * @param mixed $sDocumentNameCode (1001)
+     * @param mixed $sDocumentIdentifier (1004)
+     *
+     * @return parent::compose()
      */
-    public function compose($msgStatus = 9, $documentCode = 129)
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
         $this->messageContent = [
-            ['BGM', $documentCode, $this->messageID, $msgStatus]
+            ['BGM', $sDocumentNameCode, $this->messageID, $sMessageFunctionCode]
         ];
+
         $this->messageContent[] = $this->dtmSend;
         $this->messageContent[] = $this->releaseNumber;
         $this->messageContent[] = $this->dtmExpiration;
+
         if ($this->previousMessage !== null) {
             $this->messageContent[] = $this->previousMessage;
         }
+
         $this->messageContent[] = $this->vessel;
         $this->messageContent[] = $this->pol;
         $this->messageContent[] = $this->pod;
@@ -230,7 +256,6 @@ class Coreor extends Message
         $this->messageContent[] = $this->freightPayer;
         $this->messageContent[] = ['CNT', [16, 1]];
 
-        parent::compose();
-        return $this;
+        return parent::compose($sMessageFunctionCode, $sDocumentNameCode, $sDocumentIdentifier);
     }
 }

--- a/src/Generator/Vermas.php
+++ b/src/Generator/Vermas.php
@@ -10,15 +10,30 @@ class Vermas extends Message
     private $messageSenderInformation = '';
     private $messageSenderCompany = ['NAD', 'TB'];
 
-    private $containers;
+    private $containers = [];
 
-    public function __construct($messageID = null, $identifier = 'VERMAS', $version = 'D', $release = '16A', $controllingAgency = 'UN', $association = 'SMDG10')
-    {
-        parent::__construct($identifier, $version, $release, $controllingAgency, $messageID, $association);
+    /**
+     * Construct.
+     *
+     * @param mixed $sMessageReferenceNumber (0062)
+     * @param string $sMessageType (0065)
+     * @param string $sMessageVersionNumber (0052)
+     * @param string $sMessageReleaseNumber (0054)
+     * @param string $sMessageControllingAgencyCoded (0051)
+     * @param string $sAssociationAssignedCode (0057)
+     */
+    public function __construct(
+        $sMessageReferenceNumber = null,
+        $sMessageType = 'VERMAS',
+        $sMessageVersionNumber = 'D',
+        $sMessageReleaseNumber = '16A',
+        $sMessageControllingAgencyCoded = 'UN',
+        $sAssociationAssignedCode = 'SMDG10'
+    ) {
+        parent::__construct($sMessageType, $sMessageVersionNumber, $sMessageReleaseNumber,
+            $sMessageControllingAgencyCoded, $sMessageReferenceNumber, $sAssociationAssignedCode);
 
         $this->dtmSend = self::dtmSegment(137, date('YmdHi'));
-
-        $this->containers = [];
     }
 
     /*
@@ -78,10 +93,19 @@ class Vermas extends Message
         return $this;
     }
 
-    public function compose($msgStatus = 5, $documentCode = 749)
+    /**
+     * Compose.
+     *
+     * @param mixed $sMessageFunctionCode (1225)
+     * @param mixed $sDocumentNameCode (1001)
+     * @param mixed $sDocumentIdentifier (1004)
+     *
+     * @return parent::compose()
+     */
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
         $this->messageContent = [
-            ['BGM', $documentCode, $this->messageID, $msgStatus]
+            ['BGM', $sDocumentNameCode, $this->messageID, $sMessageFunctionCode]
         ];
 
         /* message creation date and time */
@@ -110,7 +134,6 @@ class Vermas extends Message
             }
         }
 
-        parent::compose();
-        return $this;
+        return parent::compose($sMessageFunctionCode, $sDocumentNameCode, $sDocumentIdentifier);
     }
 }

--- a/src/Generator/Westim.php
+++ b/src/Generator/Westim.php
@@ -19,14 +19,28 @@ class Westim extends Message
     private $_costTotals;
     private $_totalMessageAmounts;
 
-    /*
-     * messageID needs to be the estimate reference number
+    /**
+     * Construct.
+     *
+     * @param mixed $sMessageReferenceNumber (0062)
+     * @param string $sMessageType (0065)
+     * @param string $sMessageVersionNumber (0052)
+     * @param string $sMessageReleaseNumber (0054)
+     * @param string $sMessageControllingAgencyCoded (0051)
+     * @param string $sAssociationAssignedCode (0057)
      */
-    public function __construct($estimateReference = null, $identifier = 'WESTIM', $version = '0', $release = null, $controllingAgency = null, $association = null)
-    {
-        parent::__construct($identifier, $version, $release, $controllingAgency, $estimateReference, $association);
+    public function __construct(
+        $sMessageReferenceNumber = null,
+        $sMessageType = 'WESTIM',
+        $sMessageVersionNumber = '0',
+        $sMessageReleaseNumber = null,
+        $sMessageControllingAgencyCoded = null,
+        $sAssociationAssignedCode = null
+    ) {
+        parent::__construct($sMessageType, $sMessageVersionNumber, $sMessageReleaseNumber,
+            $sMessageControllingAgencyCoded, $sMessageReferenceNumber, $sAssociationAssignedCode);
         
-        $this->_estimateReference = $estimateReference;
+        $this->_estimateReference = $sMessageReferenceNumber;
 
         $this->_damages = [];
     }
@@ -124,10 +138,18 @@ class Westim extends Message
         return $this;
     }
 
-    public function compose($msgStatus = null)
+    /**
+     * Compose.
+     *
+     * @param mixed $sMessageFunctionCode (1225)
+     * @param mixed $sDocumentNameCode (1001)
+     * @param mixed $sDocumentIdentifier (1004)
+     *
+     * @return parent::compose()
+     */
+    public function compose(?string $sMessageFunctionCode = null, ?string $sDocumentNameCode = null, ?string $sDocumentIdentifier = null): parent
     {
-        $this->messageContent = [
-        ];
+        $this->messageContent = [];
 
         $this->messageContent[] = $this->_dtmATR;
         $this->messageContent[] = ['RFF', 'EST', $this->_estimateReference, $this->_day];
@@ -136,13 +158,16 @@ class Westim extends Message
         $this->messageContent[] = $this->_nadLED;
         $this->messageContent[] = $this->_nadDED;
         $this->messageContent[] = $this->_equipment;
+
         if ($this->_fullEmpty !== null) {
             $this->messageContent[] = $this->_fullEmpty;
         }
+
         $this->messageContent[] = ['ECI', 'D'];
 
         foreach ($this->_damages as $damage) {
             $content = $damage->compose();
+
             foreach ($content as $segment) {
                 $this->messageContent[] = $segment;
             }
@@ -151,7 +176,6 @@ class Westim extends Message
         $this->messageContent[] = $this->_costTotals;
         $this->messageContent[] = $this->_totalMessageAmounts;
 
-        parent::compose();
-        return $this;
+        return parent::compose($sMessageFunctionCode, $sDocumentNameCode, $sDocumentIdentifier);
     }
 }


### PR DESCRIPTION
I updated the legacy Class structure to be compatible with the Message Class (__construct() and compose() function).

@sabas
I try to keep the different Messages backworth compatible.
In your current project, you MUST now set the Document Name Code parameter (2nd) when calling compose(), before they are set default in the constructor.
It's RECOMMEND to use the new Segment Groups approach as introduced in the Cohaor Message.
On the horizon all Message Classes should be simplified like to Cohaor Message Class, but that is up to you, because you must make changes in your current project.