### PR TITLE
Fixed outdated/wrong code hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-The classes provided by this package give a fluent interface which simplifies the encoding of an EDI (mainly UN/EDIFACT) message.
+The classes provided by this package give a fluent interface
+which simplifies the encoding of an EDI (mainly UN/EDIFACT) message.
 
-The resulting array can be encoded in a valid message with EDI\Encoder class provided by [https://github.com/PHPEdifact/edifact](https://github.com/PHPEdifact/edifact).
+The resulting array can be encoded in a valid message with EDI\Encoder class provided
+by [https://github.com/PHPEdifact/edifact](https://github.com/PHPEdifact/edifact).
 
 Each message type extends a generic Message class which provides common helpers.
 

--- a/src/Generator/Base.php
+++ b/src/Generator/Base.php
@@ -138,20 +138,20 @@ class Base
     }
 
     /**
-     * @param     $dateString
-     * @param     $type
+     * @param string|\DateTime $date
+     * @param string $type
      * @param int $formatQualifier
      *
-     * @see http://www.unece.org/trade/untdid/d96a/trsd/trsddtm.htm
      * @return array
      * @throws EdifactException
+     * @see http://www.unece.org/trade/untdid/d96a/trsd/trsddtm.htm
      */
-    protected function addDTMSegment($dateString, $type, $formatQualifier = EdifactDate::DATE)
+    protected function addDTMSegment($date, $type, $formatQualifier = EdifactDate::DATE)
     {
         $data = [];
         $data[] = (string)$type;
-        if (!empty($dateString)) {
-            $data[] = EdifactDate::get($dateString, $formatQualifier);
+        if (!empty($date)) {
+            $data[] = EdifactDate::get($date, $formatQualifier);
             $data[] = (string)$formatQualifier;
         }
 
@@ -198,7 +198,7 @@ class Base
      *
      * @param      $value
      * @param      $array
-     *@param $errorMessage
+     * @param $errorMessage
      *
      * @throws EdifactException
      */

--- a/src/Generator/EdifactDate.php
+++ b/src/Generator/EdifactDate.php
@@ -72,33 +72,32 @@ class EdifactDate
     }
 
     /**
-     * @param string|\DateTime $string
+     * @param string|\DateTime $date
      * @param integer $format
      *
      * @return bool|\DateTime
      */
-    public static function parseFormat($string, $format = self::DATE)
+    public static function parseFormat($date, $format = self::DATE)
     {
-        if ($string instanceof \DateTime) {
-            return $string;
+        if ($date instanceof \DateTime) {
+            return $date;
         }
 
         $parseFormat = 'Y-m-d';
         switch ($format) {
             case self::DATE:
-                $string = substr($string, 0, 10);
-                $parseFormat = 'Y-m-d';
+                $date = substr($date, 0, 10);
                 break;
             case
 
             self::DATETIME:
                 $parseFormat = 'Y-m-d H:i:s';
-                if (strlen($string) === 16) {
+                if (strlen($date) === 16) {
                     $parseFormat = 'Y-m-d H:i';
                 }
                 break;
         }
 
-        return \DateTime::createFromFormat($parseFormat, $string);
+        return \DateTime::createFromFormat($parseFormat, $date);
     }
 }

--- a/src/Generator/Orders.php
+++ b/src/Generator/Orders.php
@@ -238,7 +238,7 @@ class Orders extends Message
     }
 
     /**
-     * @param array $orderDate
+     * @param string|\DateTime $orderDate
      * @return Orders
      * @throws EdifactException
      */


### PR DESCRIPTION
`Orders::setOrderDate()` doesn't actually expect an `array` but either a `string` or a `DateTime` object.

Also added 2 line-breaks in the README…