### PR TITLE
Remove declaration that is also declared in child classes and traits

### DIFF
--- a/src/Generator/Base.php
+++ b/src/Generator/Base.php
@@ -20,7 +20,6 @@ class Base
 
     /** @var string */
     protected $receiver;
-    protected $composeKeys;
 
     /** @var string */
 //    protected $managingOrganisation = '89';


### PR DESCRIPTION
Issue #31
Having this declaration in the Base model results in an error when using PHP 8.3 due to redeclaration with a different definition