### PR TITLE
PHP-8.3 AllowDynamicProperties in Traits/Item

### DIFF
--- a/src/Generator/Invoic/Item.php
+++ b/src/Generator/Invoic/Item.php
@@ -11,6 +11,7 @@ use EDI\Generator\Traits\Item as ItemTrait;
  * Class Item
  * @package EDI\Generator\Invoic
  */
+#[\AllowDynamicProperties]
 class Item extends Base
 {
     use ItemTrait;

--- a/src/Generator/Traits/Item.php
+++ b/src/Generator/Traits/Item.php
@@ -9,7 +9,6 @@ use EDI\Generator\EdifactDate;
  *
  * @package EDI\Generator\Traits
  */
-#[\AllowDynamicProperties]
 trait Item
 {
     /** @var array */

--- a/src/Generator/Traits/NameAndAddress.php
+++ b/src/Generator/Traits/NameAndAddress.php
@@ -694,7 +694,8 @@ trait NameAndAddress
         $zipCode = '',
         $city = '',
         $countryCode = 'DE',
-        $managingOrganisation = 'ZZZ'
+        $managingOrganisation = 'ZZZ',
+        $sender = null
     ) {
         $this->invoiceAddress = $this->addNameAndAddress(
             $name1,
@@ -705,7 +706,8 @@ trait NameAndAddress
             $city,
             $countryCode,
             $managingOrganisation,
-            'IV'
+            'IV',
+            $sender ?? ''
         );
         return $this;
     }


### PR DESCRIPTION
Temp workaround for issues with dynamic properties:

PHP Deprecated:  Creation of dynamic property EDI\Generator\Desadv\Item::$additionalText0 is deprecated in vendor/php-edifact/edifact-generator/src/Generator/Traits/Item.php on line 300