### PR TITLE
Fix incorrect class name in Segments trait

### DIFF
--- a/src/Generator/Traits/Segments.php
+++ b/src/Generator/Traits/Segments.php
@@ -2,7 +2,7 @@
 namespace EDI\Generator\Traits;
 
 use EDI\Generator\EdiFactNumber;
-use EDI\Generator\EdiFactDate;
+use EDI\Generator\EdifactDate;
 
 trait Segments
 {


### PR DESCRIPTION
The segments trait had the incorrect class name "Edi**F**actDate instead of EdifactDate. This led to an `Class "EDI\Generator\EdiFactDate" not found` error when trying to set a DTM element.